### PR TITLE
KDE KF6 update

### DIFF
--- a/org.kde.index.json
+++ b/org.kde.index.json
@@ -2,7 +2,7 @@
     "id": "org.kde.index",
     "rename-icon": "index",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-23.08",
+    "runtime-version": "6.7",
     "sdk": "org.kde.Sdk",
     "command": "index",
     "finish-args": [

--- a/org.kde.index.json
+++ b/org.kde.index.json
@@ -6,12 +6,12 @@
     "sdk": "org.kde.Sdk",
     "command": "index",
     "finish-args": [
+        "--device=dri",
+        "--filesystem=host",
         "--share=ipc",
         "--share=network",
         "--socket=fallback-x11",
-        "--socket=wayland",
-        "--device=dri",
-        "--filesystem=host"
+        "--socket=wayland"
     ],
     "modules": [
         {

--- a/org.kde.index.json
+++ b/org.kde.index.json
@@ -52,8 +52,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/maui/mauiman/3.1.0/mauiman-3.1.0.tar.xz",
-                    "sha256": "5c741f1fcff75f4c69fd8ef86cd428930254222cf7f58b87cad228ba3a92c290",
+                    "url": "https://download.kde.org/stable/maui/mauiman/4.0.0/mauiman-4.0.0.tar.xz",
+                    "sha256": "628a6e85c48e699ef1b57ad8b52e994c32824f687ca11155e2ea8437ae0cb233",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 315311,
@@ -69,8 +69,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "sha256": "bf5216cbb93767e0e54ac11f02e057a0a93173f8c10354ccf7eece568356f6ec",
-                    "url": "https://download.kde.org/stable/maui/mauikit/3.1.0/mauikit-3.1.0.tar.xz",
+                    "sha256": "a5fbc22f5b19b11b569c8a9585c2e3b64d3226f7bf8f4b92014953403d10e1d2",
+                    "url": "https://download.kde.org/stable/maui/mauikit/4.0.0/mauikit-4.0.0.tar.xz",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 242845,
@@ -86,8 +86,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/maui/mauikit-filebrowsing/3.1.0/mauikit-filebrowsing-3.1.0.tar.xz",
-                    "sha256": "77f7a531e4ed9643bf3bdcb8bd493973c1bb285f54aaaf822b024fb23075d190",
+                    "url": "https://download.kde.org/stable/maui/mauikit-filebrowsing/4.0.0/mauikit-filebrowsing-4.0.0.tar.xz",
+                    "sha256": "b93edb5b07fd1fd74f4b46d5bb1402c57370728038e7e407dba1be3730f1da2e",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 242845,
@@ -103,8 +103,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kio-extras-23.08.5.tar.xz",
-                    "sha256": "1ae0ec1cc7239fd4fa46d8cb2629ceb364d4a70e7e56075d2ebfef68eb1b263f",
+                    "url": "https://download.kde.org/stable/release-service/24.08.0/src/kio-extras-24.08.0.tar.xz",
+                    "sha256": "7590f4897962388149c0fec25e7eb8b691597dacfd4aedf3343bbeeb4b98445c",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -120,8 +120,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/maui/index/3.1.0/index-fm-3.1.0.tar.xz",
-                    "sha256": "cf1740369d6e8ba89689003aaff8368e8b7675caa9ceb1b007cc361a33e9fb8e",
+                    "url": "https://download.kde.org/stable/maui/index/4.0.0/index-fm-4.0.0.tar.xz",
+                    "sha256": "889a0b960377fb97d784421958d55d22ada803894bcce2a3e0214314bf653f87",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 242960,


### PR DESCRIPTION
mauiman: Update mauiman-3.1.0.tar.xz to 4.0.0
mauikit: Update mauikit-3.1.0.tar.xz to 4.0.0
mauikit-filebrowsing: Update mauikit-filebrowsing-3.1.0.tar.xz to 4.0.0
kio-extras: Update kio-extras-23.08.5.tar.xz to 24.08.0
index-fm: Update index-fm-3.1.0.tar.xz to 4.0.0